### PR TITLE
fix uv error on setup venv

### DIFF
--- a/scripts/install-backend.sh
+++ b/scripts/install-backend.sh
@@ -40,6 +40,7 @@ echo -e "\n${YELLOW}[4/5] Creating Python environment...${NC}"
 mkdir -p "$INSTALL_DIR/backend"
 cd "$INSTALL_DIR/backend"
 
+uv self update
 uv venv --python 3.13.11
 uv pip install websockets==15.0.1 dbus-python==1.4.0
 


### PR DESCRIPTION
This fixes the following error when installing the backend on ArchLinux due to outdated uv:

error: No interpreter found for Python 3.13.11 in managed installations or search path