### PR TITLE
feat(v2): add lyrics alignment settings and scrolling functionality.

### DIFF
--- a/kde/v2/contents/config/main.xml
+++ b/kde/v2/contents/config/main.xml
@@ -39,8 +39,8 @@
         <entry name="lyricTextVerticalOffset" type="Int">
             <default>0</default>
         </entry>
-        <entry name="lyricTextAlignment" type="String">
-            <default>right</default>
+        <entry name="lyricTextAlignment" type="int">
+            <default>2</default>
         </entry>
         <entry name="whiteMediaControlIconsChecked" type="Bool">
             <default>false</default>

--- a/kde/v2/contents/config/main.xml
+++ b/kde/v2/contents/config/main.xml
@@ -39,6 +39,9 @@
         <entry name="lyricTextVerticalOffset" type="Int">
             <default>0</default>
         </entry>
+        <entry name="lyricTextAlignment" type="String">
+            <default>right</default>
+        </entry>
         <entry name="whiteMediaControlIconsChecked" type="Bool">
             <default>false</default>
         </entry>

--- a/kde/v2/contents/ui/configGeneral.qml
+++ b/kde/v2/contents/ui/configGeneral.qml
@@ -19,6 +19,7 @@ Kirigami.FormLayout {
     property alias cfg_lyricTextBold: boldButton.checked   
     property alias cfg_lyricTextItalic: italicButton.checked 
     property alias cfg_lyricTextVerticalOffset: lyricTextVerticalOffsetSpinBox.value
+    property alias cfg_lyricTextAlignment: lyricTextAlignmentComboBox.currentIndex
 
     property alias cfg_mediaControllSpacing: mediaControllSpacingSpinBox.value
     property alias cfg_mediaControllItemSize: mediaControllItemSizeSpinBox.value
@@ -58,6 +59,16 @@ Kirigami.FormLayout {
     QQC2.SpinBox {
         id: lyricTextVerticalOffsetSpinBox
         Kirigami.FormData.label: i18n("Lyric text vertical offset: ")
+    }
+
+    QQLayouts.RowLayout {
+        Kirigami.FormData.label: i18n("Lyric text alignment: ")
+        
+        QQC2.ComboBox {
+            id: lyricTextAlignmentComboBox
+            model: [i18n("Left"), i18n("Center"), i18n("Right")]
+            currentIndex: 2 // Default to right
+        }
     }
 
     QQC2.SpinBox {

--- a/kde/v2/contents/ui/configGeneral.qml
+++ b/kde/v2/contents/ui/configGeneral.qml
@@ -67,7 +67,7 @@ Kirigami.FormLayout {
         QQC2.ComboBox {
             id: lyricTextAlignmentComboBox
             model: [i18n("Left"), i18n("Center"), i18n("Right")]
-            currentIndex: 2 // Default to right
+            currentIndex: 2
         }
     }
 

--- a/kde/v2/contents/ui/main.qml
+++ b/kde/v2/contents/ui/main.qml
@@ -48,7 +48,6 @@ PlasmoidItem {
                 // 容器宽度改变时，重置动画和位置
                 if (lyricBounceAnimation.running) {
                     lyricBounceAnimation.stop()
-                    lyricText.xPosition = 0
                     restartTimer.start()
                 }
             }
@@ -63,6 +62,7 @@ PlasmoidItem {
                 id: lyricBounceAnimation
                 running: lyricTextMetrics.width > lyricTextContainer.width && playbackStatus === "playing"
                 loops: Animation.Infinite
+                property int animationDuration: Math.max(2000, Math.abs((lyricTextContainer.width - lyricTextMetrics.width) / 50 * 1000))
 
                 // 第一段：从左到右
                 PropertyAnimation {
@@ -70,7 +70,7 @@ PlasmoidItem {
                     property: "xPosition"
                     from: 0
                     to: lyricTextContainer.width - lyricTextMetrics.width
-                    duration: Math.max(2000, Math.abs((lyricTextContainer.width - lyricTextMetrics.width) / 50 * 1000))
+                    duration: animationDuration
                     easing.type: Easing.Linear
                 }
 
@@ -82,7 +82,7 @@ PlasmoidItem {
                     property: "xPosition"
                     from: lyricTextContainer.width - lyricTextMetrics.width
                     to: 0
-                    duration: Math.max(2000, Math.abs((lyricTextContainer.width - lyricTextMetrics.width) / 50 * 1000))
+                    duration: animationDuration
                     easing.type: Easing.Linear
                 }
 
@@ -113,9 +113,6 @@ PlasmoidItem {
                 anchors.verticalCenter: parent.verticalCenter
                 anchors.verticalCenterOffset: config_lyricTextVerticalOffset
                 
-                horizontalAlignment: config_lyricTextAlignment === 0 ? Text.AlignLeft : 
-                                    (config_lyricTextAlignment === 1 ? Text.AlignHCenter : Text.AlignRight)
-                
                 property real initialXPosition: {
                     // 计算初始对齐位置（仅在文本不滚动时使用）
                     if (config_lyricTextAlignment === 0) {
@@ -136,10 +133,6 @@ PlasmoidItem {
                 onTextChanged: {
                     // 歌词切换时，重置动画和位置
                     lyricBounceAnimation.stop()
-                    
-                    // 强制重置到左侧起始位置
-                    lyricText.xPosition = 0
-                    
                     // 延迟后启动动画
                     restartTimer.start()
                 }

--- a/kde/v2/contents/ui/main.qml
+++ b/kde/v2/contents/ui/main.qml
@@ -45,7 +45,6 @@ PlasmoidItem {
             clip: true
 
             onWidthChanged: {
-                // 容器宽度改变时，重置动画和位置
                 if (lyricBounceAnimation.running) {
                     lyricBounceAnimation.stop()
                     restartTimer.start()
@@ -63,7 +62,6 @@ PlasmoidItem {
                 running: lyricTextMetrics.width > lyricTextContainer.width && playbackStatus === "playing"
                 loops: Animation.Infinite
 
-                // 第一段：从左到右
                 PropertyAnimation {
                     target: lyricText
                     property: "xPosition"
@@ -75,7 +73,6 @@ PlasmoidItem {
 
                 PauseAnimation { duration: 1000 }
 
-                // 第二段：从右到左
                 PropertyAnimation {
                     target: lyricText
                     property: "xPosition"
@@ -95,7 +92,6 @@ PlasmoidItem {
                 repeat: false
                 onTriggered: {
                     if (lyricTextMetrics.width > lyricTextContainer.width && playbackStatus === "playing") {
-                        // 确保位置在左侧，然后启动动画
                         lyricText.xPosition = 0
                         lyricBounceAnimation.start()
                     }
@@ -113,13 +109,12 @@ PlasmoidItem {
                 anchors.verticalCenterOffset: config_lyricTextVerticalOffset
                 
                 property real initialXPosition: {
-                    // 计算初始对齐位置（仅在文本不滚动时使用）
                     if (config_lyricTextAlignment === 0) {
-                        return 0 // Left
+                        return 0
                     } else if (config_lyricTextAlignment === 1) {
-                        return (lyricTextContainer.width - lyricTextMetrics.width) / 2 // Center
+                        return (lyricTextContainer.width - lyricTextMetrics.width) / 2
                     } else {
-                        return lyricTextContainer.width - lyricTextMetrics.width // Right
+                        return lyricTextContainer.width - lyricTextMetrics.width
                     }
                 }
                 
@@ -130,9 +125,7 @@ PlasmoidItem {
                     : xPosition
 
                 onTextChanged: {
-                    // 歌词切换时，重置动画和位置
                     lyricBounceAnimation.stop()
-                    // 延迟后启动动画
                     restartTimer.start()
                 }
             }
@@ -310,8 +303,6 @@ PlasmoidItem {
     property bool hasActivePlayer: false
     property var availablePlayers: []
     property string selectedPlayer: ""
-
-    // 计算动画持续时间
     property int animationDuration: Math.max(2000, Math.abs((lyricTextContainer.width - lyricTextMetrics.width) / 50 * 1000))
 
     property string requestedPlayer: {

--- a/kde/v2/contents/ui/main.qml
+++ b/kde/v2/contents/ui/main.qml
@@ -62,7 +62,6 @@ PlasmoidItem {
                 id: lyricBounceAnimation
                 running: lyricTextMetrics.width > lyricTextContainer.width && playbackStatus === "playing"
                 loops: Animation.Infinite
-                property int animationDuration: Math.max(2000, Math.abs((lyricTextContainer.width - lyricTextMetrics.width) / 50 * 1000))
 
                 // 第一段：从左到右
                 PropertyAnimation {
@@ -311,6 +310,9 @@ PlasmoidItem {
     property bool hasActivePlayer: false
     property var availablePlayers: []
     property string selectedPlayer: ""
+
+    // 计算动画持续时间
+    property int animationDuration: Math.max(2000, Math.abs((lyricTextContainer.width - lyricTextMetrics.width) / 50 * 1000))
 
     property string requestedPlayer: {
         if (selectedPlayer) {

--- a/kde/v2/contents/ui/main.qml
+++ b/kde/v2/contents/ui/main.qml
@@ -42,6 +42,66 @@ PlasmoidItem {
             id: lyricTextContainer
             Layout.fillWidth: true
             Layout.fillHeight: true
+            clip: true
+
+            onWidthChanged: {
+                // 容器宽度改变时，重置动画和位置
+                if (lyricBounceAnimation.running) {
+                    lyricBounceAnimation.stop()
+                    lyricText.xPosition = 0
+                    restartTimer.start()
+                }
+            }
+
+            TextMetrics {
+                id: lyricTextMetrics
+                font: lyricText.font
+                text: currentLyric || lrc_not_exists
+            }
+
+            SequentialAnimation {
+                id: lyricBounceAnimation
+                running: lyricTextMetrics.width > lyricTextContainer.width && playbackStatus === "playing"
+                loops: Animation.Infinite
+
+                // 第一段：从左到右
+                PropertyAnimation {
+                    target: lyricText
+                    property: "xPosition"
+                    from: 0
+                    to: lyricTextContainer.width - lyricTextMetrics.width
+                    duration: Math.max(2000, Math.abs((lyricTextContainer.width - lyricTextMetrics.width) / 50 * 1000))
+                    easing.type: Easing.Linear
+                }
+
+                PauseAnimation { duration: 1000 }
+
+                // 第二段：从右到左
+                PropertyAnimation {
+                    target: lyricText
+                    property: "xPosition"
+                    from: lyricTextContainer.width - lyricTextMetrics.width
+                    to: 0
+                    duration: Math.max(2000, Math.abs((lyricTextContainer.width - lyricTextMetrics.width) / 50 * 1000))
+                    easing.type: Easing.Linear
+                }
+
+                PauseAnimation { duration: 1000 }
+            }
+
+            Timer {
+                id: restartTimer
+                interval: 50
+                running: false
+                repeat: false
+                onTriggered: {
+                    if (lyricTextMetrics.width > lyricTextContainer.width && playbackStatus === "playing") {
+                        // 确保位置在左侧，然后启动动画
+                        lyricText.xPosition = 0
+                        lyricBounceAnimation.start()
+                    }
+                }
+            }
 
             Text {
                 id: lyricText
@@ -50,9 +110,39 @@ PlasmoidItem {
                 font.pixelSize: config_lyricTextSize
                 font.bold: config_lyricTextBold
                 font.italic: config_lyricTextItalic
-                anchors.right: parent.right
                 anchors.verticalCenter: parent.verticalCenter
                 anchors.verticalCenterOffset: config_lyricTextVerticalOffset
+                
+                horizontalAlignment: config_lyricTextAlignment === 0 ? Text.AlignLeft : 
+                                    (config_lyricTextAlignment === 1 ? Text.AlignHCenter : Text.AlignRight)
+                
+                property real initialXPosition: {
+                    // 计算初始对齐位置（仅在文本不滚动时使用）
+                    if (config_lyricTextAlignment === 0) {
+                        return 0 // Left
+                    } else if (config_lyricTextAlignment === 1) {
+                        return (lyricTextContainer.width - lyricTextMetrics.width) / 2 // Center
+                    } else {
+                        return lyricTextContainer.width - lyricTextMetrics.width // Right
+                    }
+                }
+                
+                property real xPosition: initialXPosition
+                
+                x: lyricTextMetrics.width <= lyricTextContainer.width || !lyricBounceAnimation.running
+                    ? initialXPosition
+                    : xPosition
+
+                onTextChanged: {
+                    // 歌词切换时，重置动画和位置
+                    lyricBounceAnimation.stop()
+                    
+                    // 强制重置到左侧起始位置
+                    lyricText.xPosition = 0
+                    
+                    // 延迟后启动动画
+                    restartTimer.start()
+                }
             }
         }
 
@@ -202,6 +292,7 @@ PlasmoidItem {
     property bool config_lyricTextBold: Plasmoid.configuration.lyricTextBold
     property bool config_lyricTextItalic: Plasmoid.configuration.lyricTextItalic
     property int config_lyricTextVerticalOffset: Plasmoid.configuration.lyricTextVerticalOffset
+    property int config_lyricTextAlignment: Plasmoid.configuration.lyricTextAlignment
 
     property int config_mediaControllSpacing: Plasmoid.configuration.mediaControllSpacing
     property int config_mediaControllItemSize: Plasmoid.configuration.mediaControllItemSize


### PR DESCRIPTION
fix #32 

## 介绍

- 添加 `Lyric Text Alignment` 配置项以设置左对齐、居中对齐、右对齐。
- 现在默认歌词超出组件长度时自动播放滚动歌词动画。

## 预览

- `Lyric Text Alignment`: Right
- `Prefered Widget Width`: 350

https://github.com/user-attachments/assets/09194057-b803-4e29-8d18-c8e7661f9289

