### PR TITLE
Fix Spotify lyric fetch reliability

### DIFF
--- a/backend/src/lyrics_manager.py
+++ b/backend/src/lyrics_manager.py
@@ -1,11 +1,15 @@
 import json
 import threading
+import time
 from pathlib import Path
 import urllib.request
 from urllib.parse import quote, unquote, urlencode, urlparse
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from mpris_prober import find_players, find_playing_players
 from mpris_player import MprisPlayer, PlaybackStatus
+
+LRCLIB_TIMEOUT = 12
+LYRICS_RETRY_INTERVAL = 10
 
 class LyricsManager:
     """
@@ -16,12 +20,15 @@ class LyricsManager:
     def __init__(self):
         self.lyrics_cache = {}
         self._fetch_id = 0
+        self._fetching_track_key = None
+        self._last_fetch_attempts = {}
         self.setup()
     
     
     def setup(self, playername=None, playerobj=None, title=None, artist=None, album=None,
               duration=0, identity=None, lyrics=None, current_lyric=None,
-              playback_status=PlaybackStatus.STOPPED, position_ms=0, available_players=None):
+              playback_status=PlaybackStatus.STOPPED, position_ms=0, available_players=None,
+              track_key=None):
         self.playername = playername
         self.playerobj = playerobj
         self.title = title
@@ -34,6 +41,7 @@ class LyricsManager:
         self.playback_status = playback_status
         self.position_ms = position_ms
         self.available_players = available_players or []
+        self.track_key = track_key
     
     
     def poll_status(self, requested_playername=None):
@@ -115,23 +123,21 @@ class LyricsManager:
             identity = current_playerobj.identity
         except Exception:
             return set_free()
-        track_changed = (self.title != track_info['title']
-                or self.artist != track_info['artist']
-                or self.album != track_info['album'])
+        track_key = self._track_key(current_playername, track_info)
+        track_changed = self.track_key != track_key
         if track_changed:
             self.title = track_info['title']
             self.artist = track_info['artist']
             self.album = track_info['album']
             # Check if this player has cached lyrics for current track
-            cached = self.lyrics_cache.get(current_playername)
-            if (cached and cached['title'] == track_info['title']
-                    and cached['artist'] == track_info['artist']
-                    and cached['album'] == track_info['album']):
-                self.lyrics = cached['lyrics']
+            cached = self.lyrics_cache.get(track_key)
+            if cached:
+                self.lyrics = cached
             else:
                 self.lyrics = None
-                self._fetch_id += 1
-                threading.Thread(target=self._fetch_lyrics, args=(current_playername, track_info, self._fetch_id), daemon=True).start()
+                self._start_lyrics_fetch(current_playername, track_info, track_key)
+        elif self._should_retry_lyrics_fetch(track_key):
+            self._start_lyrics_fetch(current_playername, track_info, track_key)
         self.position_ms = position
         current_lyric = self._get_current_lyric()
         self.setup(
@@ -146,24 +152,52 @@ class LyricsManager:
             current_lyric=current_lyric,
             playback_status=playback_status,
             position_ms=position,
-            available_players=playernames
+            available_players=playernames,
+            track_key=track_key
         )
         return self.get_state()
 
+    def _track_key(self, playername, track_info):
+        return (
+            playername,
+            track_info['title'],
+            tuple(track_info['artist']),
+            track_info['album'],
+            track_info['length'],
+        )
 
-    def _fetch_lyrics(self, playername, track_info, fetch_id):
+
+    def _should_retry_lyrics_fetch(self, track_key):
+        if self.lyrics or self._fetching_track_key == track_key:
+            return False
+        last_attempt = self._last_fetch_attempts.get(track_key, 0)
+        return time.monotonic() - last_attempt >= LYRICS_RETRY_INTERVAL
+
+
+    def _start_lyrics_fetch(self, playername, track_info, track_key):
+        self._fetch_id += 1
+        self._fetching_track_key = track_key
+        self._last_fetch_attempts[track_key] = time.monotonic()
+        threading.Thread(
+            target=self._fetch_lyrics,
+            args=(playername, track_info, track_key, self._fetch_id),
+            daemon=True
+        ).start()
+
+
+    def _fetch_lyrics(self, playername, track_info, track_key, fetch_id):
         # Check if this fetch is still current
         if self._fetch_id != fetch_id:
             return
-        title = track_info['title']
-        artists = track_info['artist']
-        artist = artists[0] if artists else ''
-        album = track_info['album']
-        length = track_info['length']
-        url = track_info['url']
-        if not title or not artists:
-            return
         try:
+            title = track_info['title']
+            artists = track_info['artist']
+            artist = artists[0] if artists else ''
+            album = track_info['album']
+            length = track_info['length']
+            url = track_info['url']
+            if not title or not artists:
+                return
             lyrics = None
             if playername == 'org.mpris.MediaPlayer2.yesplaymusic':
                 lyrics = self._fetch_lyrics_ypm(title)
@@ -180,15 +214,14 @@ class LyricsManager:
             if self._fetch_id == fetch_id:
                 self.lyrics = lyrics
                 if lyrics:
-                    self.lyrics_cache[playername] = {
-                        'title': title,
-                        'artist': artists,
-                        'album': album,
-                        'lyrics': lyrics
-                    }
+                    self.lyrics_cache[track_key] = lyrics
         except Exception as e:
             if self._fetch_id == fetch_id:
                 self.lyrics = None
+        finally:
+            if self._fetch_id == fetch_id:
+                if self._fetching_track_key == track_key:
+                    self._fetching_track_key = None
 
 
     def _http_get(self, url, timeout=5):
@@ -249,7 +282,7 @@ class LyricsManager:
             if not duration_sec:
                 return None
             url = f"https://lrclib.net/api/get?{params}&duration={duration_sec}"
-            status, text = self._http_get(url)
+            status, text = self._http_get(url, timeout=LRCLIB_TIMEOUT)
             if status == 200 and text:
                 data = json.loads(text)
                 return data.get('syncedLyrics')
@@ -257,7 +290,7 @@ class LyricsManager:
 
         def fetch_search():
             url = f"https://lrclib.net/api/search?{params}"
-            status, text = self._http_get(url)
+            status, text = self._http_get(url, timeout=LRCLIB_TIMEOUT)
             if status == 200 and text:
                 data = json.loads(text)
                 for result in data:
@@ -267,7 +300,7 @@ class LyricsManager:
 
         def fetch_fuzzy():
             url = f"https://lrclib.net/api/search?q={quote(title)}"
-            status, text = self._http_get(url)
+            status, text = self._http_get(url, timeout=LRCLIB_TIMEOUT)
             if status == 200 and text:
                 data = json.loads(text)
                 for result in data:
@@ -355,6 +388,8 @@ class LyricsManager:
             "position_ms": self.position_ms,
             "lyrics": {
                 'current_lyric': self.current_lyric,
+                'available': bool(self.lyrics),
+                'fetching': self._fetching_track_key == self.track_key,
             },
             "available_players": self.available_players
         }

--- a/backend/src/lyrics_manager.py
+++ b/backend/src/lyrics_manager.py
@@ -10,6 +10,7 @@ from mpris_player import MprisPlayer, PlaybackStatus
 
 LRCLIB_TIMEOUT = 12
 LYRICS_RETRY_INTERVAL = 10
+MAX_LYRICS_FETCH_ATTEMPTS = 3
 
 class LyricsManager:
     """
@@ -18,10 +19,12 @@ class LyricsManager:
     Note: ms here == microseconds, not miliseconds.
     """
     def __init__(self):
+        self._lock = threading.RLock()
         self.lyrics_cache = {}
         self._fetch_id = 0
         self._fetching_track_key = None
         self._last_fetch_attempts = {}
+        self._fetch_attempts_count = {}
         self.setup()
     
     
@@ -29,19 +32,20 @@ class LyricsManager:
               duration=0, identity=None, lyrics=None, current_lyric=None,
               playback_status=PlaybackStatus.STOPPED, position_ms=0, available_players=None,
               track_key=None):
-        self.playername = playername
-        self.playerobj = playerobj
-        self.title = title
-        self.artist = artist
-        self.album = album
-        self.duration = duration
-        self.identity = identity
-        self.lyrics = lyrics
-        self.current_lyric = current_lyric
-        self.playback_status = playback_status
-        self.position_ms = position_ms
-        self.available_players = available_players or []
-        self.track_key = track_key
+        with self._lock:
+            self.playername = playername
+            self.playerobj = playerobj
+            self.title = title
+            self.artist = artist
+            self.album = album
+            self.duration = duration
+            self.identity = identity
+            self.lyrics = lyrics
+            self.current_lyric = current_lyric
+            self.playback_status = playback_status
+            self.position_ms = position_ms
+            self.available_players = available_players or []
+            self.track_key = track_key
     
     
     def poll_status(self, requested_playername=None):
@@ -72,7 +76,8 @@ class LyricsManager:
         
         if not playernames:
             return set_free()
-        current_playername = self.playername
+        with self._lock:
+            current_playername = self.playername
         current_playerobj = None
         if requested_playername:
              if requested_playername in playernames:
@@ -82,13 +87,15 @@ class LyricsManager:
         else:
             # Global mode: find the best player
             # If we have a current player, check if it's still valid
-            if self.playername and self.playername in playernames:
+            with self._lock:
+                previous_playername = self.playername
+            if previous_playername and previous_playername in playernames:
                 try:
-                    player = MprisPlayer(self.playername)
+                    player = MprisPlayer(previous_playername)
                     if player.obj:
                         if player.playback_status == PlaybackStatus.PLAYING:
                             # Current player is playing, use it
-                            current_playername = self.playername
+                            current_playername = previous_playername
                             current_playerobj = player
                         else:
                             # Current player paused/stopped, check for other playing players
@@ -97,7 +104,7 @@ class LyricsManager:
                                 current_playername = playing_playernames[0]
                             else:
                                 # No playing player, keep current one
-                                current_playername = self.playername
+                                current_playername = previous_playername
                                 current_playerobj = player
                 except Exception:
                     pass
@@ -123,39 +130,40 @@ class LyricsManager:
             identity = current_playerobj.identity
         except Exception:
             return set_free()
-        track_key = self._track_key(current_playername, track_info)
-        track_changed = self.track_key != track_key
-        if track_changed:
-            self.title = track_info['title']
-            self.artist = track_info['artist']
-            self.album = track_info['album']
-            # Check if this player has cached lyrics for current track
-            cached = self.lyrics_cache.get(track_key)
-            if cached:
-                self.lyrics = cached
-            else:
-                self.lyrics = None
-                self._start_lyrics_fetch(current_playername, track_info, track_key)
-        elif self._should_retry_lyrics_fetch(track_key):
-            self._start_lyrics_fetch(current_playername, track_info, track_key)
-        self.position_ms = position
-        current_lyric = self._get_current_lyric()
-        self.setup(
-            playername=current_playername,
-            playerobj=current_playerobj,
-            title=track_info['title'],
-            artist=track_info['artist'],
-            album=track_info['album'],
-            duration=track_info['length'],
-            identity=identity,
-            lyrics=self.lyrics,
-            current_lyric=current_lyric,
-            playback_status=playback_status,
-            position_ms=position,
-            available_players=playernames,
-            track_key=track_key
-        )
-        return self.get_state()
+        with self._lock:
+            track_key = self._track_key(current_playername, track_info)
+            track_changed = self.track_key != track_key
+            if track_changed:
+                self.title = track_info['title']
+                self.artist = track_info['artist']
+                self.album = track_info['album']
+                # Check if this player has cached lyrics for current track
+                cached = self.lyrics_cache.get(track_key)
+                if cached:
+                    self.lyrics = cached
+                else:
+                    self.lyrics = None
+                    self._start_lyrics_fetch_locked(current_playername, track_info, track_key)
+            elif self._should_retry_lyrics_fetch_locked(track_key):
+                self._start_lyrics_fetch_locked(current_playername, track_info, track_key)
+            self.position_ms = position
+            current_lyric = self._get_current_lyric()
+            self.setup(
+                playername=current_playername,
+                playerobj=current_playerobj,
+                title=track_info['title'],
+                artist=track_info['artist'],
+                album=track_info['album'],
+                duration=track_info['length'],
+                identity=identity,
+                lyrics=self.lyrics,
+                current_lyric=current_lyric,
+                playback_status=playback_status,
+                position_ms=position,
+                available_players=playernames,
+                track_key=track_key
+            )
+            return self.get_state()
 
     def _track_key(self, playername, track_info):
         return (
@@ -168,27 +176,46 @@ class LyricsManager:
 
 
     def _should_retry_lyrics_fetch(self, track_key):
+        with self._lock:
+            return self._should_retry_lyrics_fetch_locked(track_key)
+
+
+    def _should_retry_lyrics_fetch_locked(self, track_key):
         if self.lyrics or self._fetching_track_key == track_key:
+            return False
+        attempts = self._fetch_attempts_count.get(track_key, 0)
+        if attempts >= MAX_LYRICS_FETCH_ATTEMPTS:
             return False
         last_attempt = self._last_fetch_attempts.get(track_key, 0)
         return time.monotonic() - last_attempt >= LYRICS_RETRY_INTERVAL
 
 
     def _start_lyrics_fetch(self, playername, track_info, track_key):
+        with self._lock:
+            return self._start_lyrics_fetch_locked(playername, track_info, track_key)
+
+
+    def _start_lyrics_fetch_locked(self, playername, track_info, track_key):
+        attempts = self._fetch_attempts_count.get(track_key, 0)
+        if attempts >= MAX_LYRICS_FETCH_ATTEMPTS:
+            return False
         self._fetch_id += 1
         self._fetching_track_key = track_key
         self._last_fetch_attempts[track_key] = time.monotonic()
+        self._fetch_attempts_count[track_key] = attempts + 1
         threading.Thread(
             target=self._fetch_lyrics,
             args=(playername, track_info, track_key, self._fetch_id),
             daemon=True
         ).start()
+        return True
 
 
     def _fetch_lyrics(self, playername, track_info, track_key, fetch_id):
         # Check if this fetch is still current
-        if self._fetch_id != fetch_id:
-            return
+        with self._lock:
+            if self._fetch_id != fetch_id:
+                return
         try:
             title = track_info['title']
             artists = track_info['artist']
@@ -207,21 +234,25 @@ class LyricsManager:
                 lyrics = self._fetch_lyrics_local(url)
                 if lyrics is None:
                     # Check again before expensive HTTP calls
-                    if self._fetch_id != fetch_id:
-                        return
+                    with self._lock:
+                        if self._fetch_id != fetch_id:
+                            return
                     lyrics = self._fetch_lyrics_lrclib(title, artist, album, length)
             # Only write if this fetch is still current
-            if self._fetch_id == fetch_id:
-                self.lyrics = lyrics
-                if lyrics:
-                    self.lyrics_cache[track_key] = lyrics
+            with self._lock:
+                if self._fetch_id == fetch_id:
+                    self.lyrics = lyrics
+                    if lyrics:
+                        self.lyrics_cache[track_key] = lyrics
         except Exception as e:
-            if self._fetch_id == fetch_id:
-                self.lyrics = None
+            with self._lock:
+                if self._fetch_id == fetch_id:
+                    self.lyrics = None
         finally:
-            if self._fetch_id == fetch_id:
-                if self._fetching_track_key == track_key:
-                    self._fetching_track_key = None
+            with self._lock:
+                if self._fetch_id == fetch_id:
+                    if self._fetching_track_key == track_key:
+                        self._fetching_track_key = None
 
 
     def _http_get(self, url, timeout=5):
@@ -371,28 +402,29 @@ class LyricsManager:
         
         
     def get_state(self):
-        if not self.playerobj:
-            return self._get_empty_state()
-        return {
-            "playback_status": self.playback_status.value.lower(),
-            "player": {
-                "identity": self.identity,
-                "bus_name": self.playername
-            },
-            "track": {
-                "title": self.title,
-                "artist": ", ".join(self.artist) if self.artist else "",
-                "album": self.album,
-                "duration": self.duration
-            },
-            "position_ms": self.position_ms,
-            "lyrics": {
-                'current_lyric': self.current_lyric,
-                'available': bool(self.lyrics),
-                'fetching': self._fetching_track_key == self.track_key,
-            },
-            "available_players": self.available_players
-        }
+        with self._lock:
+            if not self.playerobj:
+                return self._get_empty_state()
+            return {
+                "playback_status": self.playback_status.value.lower(),
+                "player": {
+                    "identity": self.identity,
+                    "bus_name": self.playername
+                },
+                "track": {
+                    "title": self.title,
+                    "artist": ", ".join(self.artist) if self.artist else "",
+                    "album": self.album,
+                    "duration": self.duration
+                },
+                "position_ms": self.position_ms,
+                "lyrics": {
+                    'current_lyric': self.current_lyric,
+                    'available': bool(self.lyrics),
+                    'fetching': self._fetching_track_key == self.track_key,
+                },
+                "available_players": self.available_players
+            }
 
 
     def _get_empty_state(self):

--- a/backend/src/server.py
+++ b/backend/src/server.py
@@ -86,8 +86,8 @@ class LyricsServer:
                     action = data.get("action")
                     player_name = data.get("player")
                     loop = asyncio.get_running_loop()
-                    success = await loop.run_in_executor(None, self._execute_control, action, player_name)
-                    await websocket.send(json.dumps({"success": success}))
+                    result = await loop.run_in_executor(None, self._execute_control, action, player_name)
+                    await websocket.send(json.dumps(result))
                 except json.JSONDecodeError:
                     await websocket.send(json.dumps({"error": "Invalid JSON"}))
         except websockets.ConnectionClosed:
@@ -95,13 +95,19 @@ class LyricsServer:
 
 
     def _execute_control(self, action, player_name):
-        """Execute playback control. Returns True on success, False on failure."""
+        """Execute playback control. Returns a JSON-serializable result."""
+        if action == "like":
+            return {
+                "success": False,
+                "action": action,
+                "error": "The active MPRIS player does not expose a like/favorite action."
+            }
         name = player_name or self.manager.playername
         if not name:
-            return False
+            return {"success": False, "action": action, "error": "No active player"}
         player = MprisPlayer(name)
         if not player or not player.obj:
-            return False
+            return {"success": False, "action": action, "error": "Player is unavailable"}
         actions = {
             "play": player.play,
             "pause": player.pause,
@@ -113,12 +119,12 @@ class LyricsServer:
             "quit": player.quit,
         }
         if action not in actions:
-            return False
+            return {"success": False, "action": action, "error": "Unknown action"}
         try:
             actions[action]()
-            return True
-        except Exception:
-            return False
+            return {"success": True, "action": action}
+        except Exception as e:
+            return {"success": False, "action": action, "error": str(e)}
 
 
     async def run(self):

--- a/backend/src/test/test_control.py
+++ b/backend/src/test/test_control.py
@@ -1,0 +1,16 @@
+import unittest
+
+from server import LyricsServer
+
+
+class ControlTest(unittest.TestCase):
+    def test_like_action_reports_unsupported(self):
+        result = LyricsServer()._execute_control("like", None)
+
+        self.assertFalse(result["success"])
+        self.assertEqual(result["action"], "like")
+        self.assertIn("like/favorite", result["error"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/src/test/test_lyrics_manager.py
+++ b/backend/src/test/test_lyrics_manager.py
@@ -2,7 +2,12 @@ import json
 import unittest
 
 import lyrics_manager
-from lyrics_manager import LRCLIB_TIMEOUT, LYRICS_RETRY_INTERVAL, LyricsManager
+from lyrics_manager import (
+    LRCLIB_TIMEOUT,
+    LYRICS_RETRY_INTERVAL,
+    MAX_LYRICS_FETCH_ATTEMPTS,
+    LyricsManager,
+)
 
 
 class LyricsManagerTest(unittest.TestCase):
@@ -51,18 +56,21 @@ class LyricsManagerTest(unittest.TestCase):
         def fake_start(playername, info, key):
             starts.append((playername, key))
             manager._last_fetch_attempts[key] = fake_monotonic()
+            manager._fetch_attempts_count[key] = manager._fetch_attempts_count.get(key, 0) + 1
 
         original_monotonic = lyrics_manager.time.monotonic
         try:
             lyrics_manager.time.monotonic = fake_monotonic
             manager._start_lyrics_fetch = fake_start
 
-            self.assertTrue(manager._should_retry_lyrics_fetch(track_key))
-            manager._start_lyrics_fetch("org.mpris.MediaPlayer2.spotify", track_info, track_key)
-            self.assertFalse(manager._should_retry_lyrics_fetch(track_key))
+            for _ in range(MAX_LYRICS_FETCH_ATTEMPTS):
+                self.assertTrue(manager._should_retry_lyrics_fetch(track_key))
+                manager._start_lyrics_fetch("org.mpris.MediaPlayer2.spotify", track_info, track_key)
+                self.assertFalse(manager._should_retry_lyrics_fetch(track_key))
+                now[0] += LYRICS_RETRY_INTERVAL
 
-            now[0] += LYRICS_RETRY_INTERVAL
-            self.assertTrue(manager._should_retry_lyrics_fetch(track_key))
+            self.assertFalse(manager._should_retry_lyrics_fetch(track_key))
+            self.assertEqual(len(starts), MAX_LYRICS_FETCH_ATTEMPTS)
         finally:
             lyrics_manager.time.monotonic = original_monotonic
 

--- a/backend/src/test/test_lyrics_manager.py
+++ b/backend/src/test/test_lyrics_manager.py
@@ -1,0 +1,71 @@
+import json
+import unittest
+
+import lyrics_manager
+from lyrics_manager import LRCLIB_TIMEOUT, LYRICS_RETRY_INTERVAL, LyricsManager
+
+
+class LyricsManagerTest(unittest.TestCase):
+    def test_lrclib_search_uses_longer_timeout_and_parses_synced_lyrics(self):
+        manager = LyricsManager()
+        calls = []
+
+        def fake_http_get(url, timeout=5):
+            calls.append((url, timeout))
+            if "/api/search?" in url and "track_name=" in url:
+                return 200, json.dumps([
+                    {"syncedLyrics": "[00:01.00]first line\n[00:02.50]second line"}
+                ])
+            return 404, ""
+
+        manager._http_get = fake_http_get
+
+        lyrics = manager._fetch_lyrics_lrclib("Title", "Artist", "Album", 226000000)
+
+        self.assertEqual(
+            lyrics,
+            [
+                {"time_ms": 1000000, "lyric": "first line"},
+                {"time_ms": 2500000, "lyric": "second line"},
+            ],
+        )
+        self.assertTrue(calls)
+        self.assertTrue(all(timeout == LRCLIB_TIMEOUT for _, timeout in calls))
+
+
+    def test_failed_fetch_retries_after_interval(self):
+        manager = LyricsManager()
+        track_info = {
+            "title": "Title",
+            "artist": ["Artist"],
+            "album": "Album",
+            "length": 1000000,
+        }
+        track_key = manager._track_key("org.mpris.MediaPlayer2.spotify", track_info)
+        starts = []
+        now = [100.0]
+
+        def fake_monotonic():
+            return now[0]
+
+        def fake_start(playername, info, key):
+            starts.append((playername, key))
+            manager._last_fetch_attempts[key] = fake_monotonic()
+
+        original_monotonic = lyrics_manager.time.monotonic
+        try:
+            lyrics_manager.time.monotonic = fake_monotonic
+            manager._start_lyrics_fetch = fake_start
+
+            self.assertTrue(manager._should_retry_lyrics_fetch(track_key))
+            manager._start_lyrics_fetch("org.mpris.MediaPlayer2.spotify", track_info, track_key)
+            self.assertFalse(manager._should_retry_lyrics_fetch(track_key))
+
+            now[0] += LYRICS_RETRY_INTERVAL
+            self.assertTrue(manager._should_retry_lyrics_fetch(track_key))
+        finally:
+            lyrics_manager.time.monotonic = original_monotonic
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/kde/v2/contents/ui/main.qml
+++ b/kde/v2/contents/ui/main.qml
@@ -179,7 +179,7 @@ PlasmoidItem {
 
                 MouseArea {
                     anchors.fill: parent
-                    onClicked: liked = !liked
+                    onClicked: sendControl("like")
                 }
             }
 
@@ -382,7 +382,11 @@ PlasmoidItem {
             try {
                 var data = JSON.parse(message)
                 if (!data.success) {
-                    console.log("Control command failed")
+                    console.log("Control command failed:", data.error || "unknown error")
+                    return
+                }
+                if (data.action === "like") {
+                    liked = !liked
                 }
             } catch (e) {
                 console.log("Error parsing control response:", e)


### PR DESCRIPTION
使用 README文档的方法装了 KDE v2 前端和后端，播放器是 Flatpak 版 Spotify。插件能正常读到歌名/歌手，也能控制播放、暂停、上一首、下一首，但歌词经常抓不到；红心按钮也只是本地切状态，并没有真的收藏。

问题：

- Spotify 的 MPRIS 只给歌曲信息和播放控制，不给歌词，也没有 like/favorite 接口。
- Spotify 这类播放器的歌词需要拿歌名、歌手、专辑、时长去 LRCLIB 现搜。原来默认 5 秒超时对本机接口够用，但对公网请求偏短。我本机能成功的 LRCLIB 请求经常要 9-13 秒。更麻烦的是，同一首歌第一次超时后不会再重试，所以会一直显示没歌词。

改动：

- LRCLIB 请求单独用 12 秒超时。
- 歌词缓存改成按具体歌曲缓存，不只按播放器缓存。
- 同一首歌抓词失败后会间隔重试。
- poll 结果里加 `lyrics.available` 和 `lyrics.fetching`。
- control 接口返回结构化结果。
- KDE v2 红心按钮不再直接假切状态；Spotify/MPRIS 不支持收藏时明确返回失败。
- 补了几个针对歌词超时、重试和红心不支持的测试。

本机环境：

- CachyOS / Arch 系
- KDE Plasma 6.7.1
- Qt 6.11.1
- Kirigami 6.27.0
- Spotify Flatpak `com.spotify.Client` 1.2.89.539.gfb3c63a3
- Flatpak runtime `org.freedesktop.Platform/x86_64/25.08`

验证：

```bash
PYTHONPATH=backend/src python -m unittest backend/src/test/test_lyrics_manager.py backend/src/test/test_control.py
python -m py_compile backend/src/lyrics_manager.py backend/src/server.py backend/src/test/test_lyrics_manager.py backend/src/test/test_control.py
git diff --check
```

另外用本机 Spotify 实测过：一开始 poll 会返回 `lyrics.fetching=true`，抓到后变成 `lyrics.available=true`，之后能持续返回同步歌词。
