### PR TITLE
Fix high CPU usage from unthrottled WebSocket polling

### DIFF
--- a/dms/contents/ui/main.qml
+++ b/dms/contents/ui/main.qml
@@ -60,6 +60,10 @@ PluginComponent {
     property bool hasActivePlayer: false
     property var availablePlayers: []
     property string selectedPlayer: ""
+    // Throttle polling so WebSocket responses don't create a busy loop.
+    readonly property int pollInterval: playbackStatus === "playing"
+        ? 250
+        : (hasActivePlayer ? 1000 : 3000)
 
     property string requestedPlayer: {
         if (selectedPlayer) {
@@ -275,10 +279,10 @@ PluginComponent {
             try {
                 var data = JSON.parse(message)
                 handlePollResponse(data)
-                sendPollRequest()
             } catch (e) {
                 console.log("Error parsing poll response:", e)
             }
+            pollTimer.restart()
         }
     }
 
@@ -312,6 +316,14 @@ PluginComponent {
             var request = { "player": requestedPlayer || null }
             pollSocket.sendTextMessage(JSON.stringify(request))
         }
+    }
+
+    Timer {
+        id: pollTimer
+        interval: root.pollInterval
+        running: false
+        repeat: false
+        onTriggered: sendPollRequest()
     }
 
     Timer {

--- a/kde/v2/contents/ui/main.qml
+++ b/kde/v2/contents/ui/main.qml
@@ -303,6 +303,10 @@ PlasmoidItem {
     property bool hasActivePlayer: false
     property var availablePlayers: []
     property string selectedPlayer: ""
+    // Throttle polling so WebSocket responses don't create a busy loop.
+    readonly property int pollInterval: playbackStatus === "playing"
+        ? 250
+        : (hasActivePlayer ? 1000 : 3000)
     property int animationDuration: Math.max(2000, Math.abs((lyricTextContainer.width - lyricTextMetrics.width) / 50 * 1000))
 
     property string requestedPlayer: {
@@ -354,10 +358,10 @@ PlasmoidItem {
             try {
                 var data = JSON.parse(message)
                 handlePollResponse(data)
-                sendPollRequest()
             } catch (e) {
                 console.log("Error parsing poll response:", e)
             }
+            pollTimer.restart()
         }
     }
 
@@ -391,6 +395,14 @@ PlasmoidItem {
             var request = { "player": requestedPlayer || null }
             pollSocket.sendTextMessage(JSON.stringify(request))
         }
+    }
+
+    Timer {
+        id: pollTimer
+        interval: root.pollInterval
+        running: false
+        repeat: false
+        onTriggered: sendPollRequest()
     }
 
     Timer {


### PR DESCRIPTION
## Summary

- replace the immediate WebSocket request/response loop with timer-based polling
- poll every 250 ms while playing, 1 s while paused, and 3 s with no active player
- apply the same fix to both the KDE Plasma v2 and DMS frontends
- keep the initial request immediate and reschedule polling even after a malformed response

## Problem

Both frontends send another poll request immediately after every response. Because the backend is local, this creates an effectively unbounded request/response loop. Each request performs several synchronous MPRIS D-Bus queries, causing sustained CPU usage in the Python backend, the session D-Bus daemon, and Plasma Shell.

## Verification

Tested the KDE Plasma v2 frontend on Plasma 6 with the Python backend. Before this change, the backend consumed roughly half of one logical CPU and contributed to about 9% total CPU usage on a 16-thread system. After throttling, the backend used 33.5 ms of CPU time during a 15-second idle sample, session D-Bus CPU time showed no measurable increase, and total system idle time returned to 95-96%.

The DMS change mirrors the identical WebSocket polling logic.

`git diff --check` passes. The test system does not have `qmllint` installed.